### PR TITLE
feat: email channel plugin for American Claw

### DIFF
--- a/extensions/email/index.ts
+++ b/extensions/email/index.ts
@@ -1,0 +1,26 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { emailPlugin } from "./src/channel.js";
+import { setEmailRuntime } from "./src/runtime.js";
+import { createEmailInboundHandler } from "./src/inbound.js";
+
+const plugin = {
+  id: "email",
+  name: "Email",
+  description: "Email channel plugin for American Claw managed hosting",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setEmailRuntime(api.runtime);
+
+    api.registerChannel({ plugin: emailPlugin });
+
+    // Register the gateway RPC method that American Claw calls
+    // when an inbound email arrives via Cloudflare Email Routing.
+    api.registerGatewayMethod(
+      "email.inbound",
+      createEmailInboundHandler(),
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/email/package.json
+++ b/extensions/email/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/email",
+  "version": "2026.2.9-1",
+  "description": "OpenClaw email channel plugin for American Claw managed hosting",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/email/src/accounts.ts
+++ b/extensions/email/src/accounts.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { EmailAccountConfig, ResolvedEmailAccount } from "./types.js";
+
+/**
+ * List all configured email account IDs.
+ */
+export function listEmailAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = (cfg.channels as Record<string, unknown> | undefined)?.email as
+    | { accounts?: Record<string, unknown> }
+    | undefined;
+  if (!accounts?.accounts) {
+    return [];
+  }
+  return Object.keys(accounts.accounts);
+}
+
+/**
+ * Resolve the default email account ID.
+ */
+export function resolveDefaultEmailAccountId(cfg: OpenClawConfig): string {
+  const ids = listEmailAccountIds(cfg);
+  if (ids.length === 0) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0];
+}
+
+/**
+ * Resolve a full email account config from the OpenClaw config.
+ */
+export function resolveEmailAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedEmailAccount {
+  const { cfg, accountId } = params;
+  const resolvedId = accountId?.trim() || resolveDefaultEmailAccountId(cfg);
+
+  const emailSection = (cfg.channels as Record<string, unknown> | undefined)?.email as
+    | { accounts?: Record<string, EmailAccountConfig> }
+    | undefined;
+
+  const raw = emailSection?.accounts?.[resolvedId] ?? {};
+
+  return {
+    accountId: resolvedId,
+    name: raw.name ?? "Email",
+    enabled: raw.enabled !== false,
+    address: raw.address ?? "",
+    outboundUrl: raw.outboundUrl ?? "",
+    outboundToken: raw.outboundToken ?? "",
+    dmPolicy: raw.dmPolicy ?? "open",
+    allowFrom: raw.allowFrom ?? [],
+  };
+}

--- a/extensions/email/src/channel.ts
+++ b/extensions/email/src/channel.ts
@@ -1,0 +1,168 @@
+/**
+ * Email channel plugin definition.
+ *
+ * This is a minimal channel plugin optimized for the American Claw use case:
+ * - Inbound arrives via gateway RPC (registered in index.ts)
+ * - Outbound is handled by the inbound handler's deliver callback
+ * - No IMAP/SMTP, no polling, no auth flows
+ * - dmPolicy defaults to "open" (email addresses are self-authenticating)
+ */
+
+import {
+  DEFAULT_ACCOUNT_ID,
+  getChatChannelMeta,
+  type ChannelPlugin,
+} from "openclaw/plugin-sdk";
+import type { ResolvedEmailAccount } from "./types.js";
+import {
+  listEmailAccountIds,
+  resolveDefaultEmailAccountId,
+  resolveEmailAccount,
+} from "./accounts.js";
+
+const meta = getChatChannelMeta("email" as never);
+
+export const emailPlugin: ChannelPlugin<ResolvedEmailAccount> = {
+  id: "email" as never,
+  meta: {
+    ...meta,
+    // Override meta defaults for email
+    id: "email" as never,
+    label: "Email",
+    icon: "email",
+    showConfigured: false,
+    quickstartAllowFrom: false,
+    forceAccountBinding: false,
+    preferSessionLookupForAnnounceTarget: false,
+  },
+  capabilities: {
+    chatTypes: ["direct"],
+    reactions: false,
+    threads: false,
+    media: false,
+    nativeCommands: false,
+    blockStreaming: false,
+  },
+  // Email channel config is written by American Claw provisioning.
+  // No user-facing onboarding wizard needed.
+  reload: { configPrefixes: ["channels.email"] },
+  gatewayMethods: ["email.inbound"],
+  config: {
+    listAccountIds: (cfg) => listEmailAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveEmailAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultEmailAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) => {
+      const accountKey = accountId || DEFAULT_ACCOUNT_ID;
+      const channels = cfg.channels as Record<string, unknown> ?? {};
+      const emailSection = channels.email as Record<string, unknown> ?? {};
+      const accounts = (emailSection.accounts ?? {}) as Record<string, Record<string, unknown>>;
+      const existing = accounts[accountKey] ?? {};
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          email: {
+            ...emailSection,
+            accounts: {
+              ...accounts,
+              [accountKey]: {
+                ...existing,
+                enabled,
+              },
+            },
+          },
+        },
+      } as typeof cfg;
+    },
+    deleteAccount: ({ cfg, accountId }) => {
+      const accountKey = accountId || DEFAULT_ACCOUNT_ID;
+      const channels = cfg.channels as Record<string, unknown> ?? {};
+      const emailSection = { ...(channels.email as Record<string, unknown> ?? {}) };
+      const accounts = { ...((emailSection.accounts ?? {}) as Record<string, unknown>) };
+      delete accounts[accountKey];
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          email: {
+            ...emailSection,
+            accounts: Object.keys(accounts).length ? accounts : undefined,
+          },
+        },
+      } as typeof cfg;
+    },
+    isEnabled: (account) => account.enabled,
+    disabledReason: () => "disabled",
+    isConfigured: (account) => Boolean(account.address && account.outboundUrl),
+    unconfiguredReason: () => "not configured",
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: Boolean(account.address && account.outboundUrl),
+      address: account.address,
+      dmPolicy: account.dmPolicy,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      resolveEmailAccount({ cfg, accountId }).allowFrom?.map((e) => String(e)),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry).trim().toLowerCase())
+        .filter(Boolean),
+  },
+  security: {
+    resolveDmPolicy: ({ account }) => ({
+      // Email is inherently "open" — anyone who knows the address can email.
+      // The address itself serves as the access control.
+      policy: account.dmPolicy ?? "open",
+      allowFrom: account.allowFrom ?? [],
+      policyPath: `channels.email.accounts.${account.accountId}.dmPolicy`,
+      allowFromPath: `channels.email.accounts.${account.accountId}.`,
+      approveHint: "Add the sender's email to channels.email.allowFrom",
+      normalizeEntry: (raw: string) => raw.toLowerCase().trim(),
+    }),
+  },
+  outbound: {
+    deliveryMode: "gateway",
+    textChunkLimit: 50000, // Email has no practical text limit
+    resolveTarget: ({ to, allowFrom }) => {
+      const trimmed = to?.trim() ?? "";
+      if (trimmed && trimmed.includes("@")) {
+        return { ok: true, to: trimmed };
+      }
+      // Fall back to first allowFrom entry
+      const firstAllow = (allowFrom ?? []).find((e) => String(e).includes("@"));
+      if (firstAllow) {
+        return { ok: true, to: String(firstAllow) };
+      }
+      return {
+        ok: false,
+        error: new Error(
+          "Email target required: provide an email address or configure channels.email.allowFrom",
+        ),
+      };
+    },
+    // sendText is not used directly — outbound is handled by the inbound
+    // handler's deliver callback which POSTs to American Claw.
+    // This is here as a fallback for any framework code that calls it.
+    sendText: async ({ to, text }) => {
+      // This should not normally be called; outbound is handled in the
+      // inbound gateway handler's deliver callback.
+      return {
+        channel: "email",
+        ok: false,
+        error: `Direct sendText not supported for email. Target: ${to}, length: ${text.length}`,
+      };
+    },
+  },
+  // Email has no persistent connection to start/stop — inbound arrives via RPC.
+  gateway: {
+    startAccount: async (ctx) => {
+      ctx.log?.info(
+        `[${ctx.accountId}] email channel ready (${ctx.account.address})`,
+      );
+      // No persistent connection needed.
+      // The "email.inbound" gateway method handles all inbound traffic.
+    },
+  },
+};

--- a/extensions/email/src/inbound.ts
+++ b/extensions/email/src/inbound.ts
@@ -1,0 +1,209 @@
+/**
+ * Gateway RPC handler for "email.inbound".
+ *
+ * Called by American Claw when an inbound email arrives via Cloudflare
+ * Email Routing. Builds a MsgContext, records the session, and dispatches
+ * the message to the agent for processing. The agent's reply is sent
+ * back via the outbound adapter (HTTP POST to American Claw).
+ */
+
+import type { GatewayRequestHandler, OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, createReplyPrefixOptions } from "openclaw/plugin-sdk";
+import { getEmailRuntime } from "./runtime.js";
+import { resolveEmailAccount } from "./accounts.js";
+import type { EmailInboundPayload } from "./types.js";
+
+/**
+ * Strip HTML tags for a plain-text fallback.
+ */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+export function createEmailInboundHandler(): GatewayRequestHandler {
+  return async (opts) => {
+    const { params, respond, context } = opts;
+    const payload = params as unknown as EmailInboundPayload;
+
+    if (!payload.from || !payload.to) {
+      respond(false, undefined, { code: 400, message: "Missing from or to" });
+      return;
+    }
+
+    const core = getEmailRuntime();
+    const cfg = context.deps.config as OpenClawConfig;
+
+    const account = resolveEmailAccount({ cfg, accountId: DEFAULT_ACCOUNT_ID });
+    if (!account.enabled || !account.address) {
+      respond(false, undefined, { code: 503, message: "Email channel not configured" });
+      return;
+    }
+
+    // Build plain text body
+    const textBody = payload.text?.trim()
+      || (payload.html ? stripHtml(payload.html) : "");
+
+    if (!textBody) {
+      respond(false, undefined, { code: 400, message: "Empty email body" });
+      return;
+    }
+
+    const subject = payload.subject ?? "(no subject)";
+    const messageId = payload.headers?.messageId;
+
+    // Resolve the agent route for this email sender
+    const senderAddress = payload.from.toLowerCase();
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "email",
+      accountId: DEFAULT_ACCOUNT_ID,
+      peer: {
+        kind: "direct",
+        id: senderAddress,
+      },
+    });
+
+    // Build the agent-facing message with email envelope context
+    const rawBody = `Subject: ${subject}\n\n${textBody}`;
+    const body = core.channel.reply.formatAgentEnvelope({
+      channel: "Email",
+      from: senderAddress,
+      timestamp: Date.now(),
+      envelope: core.channel.reply.resolveEnvelopeFormatOptions(cfg),
+      body: rawBody,
+    });
+
+    // Finalize inbound context (sets CommandAuthorized, etc.)
+    const ctxPayload = core.channel.reply.finalizeInboundContext({
+      Body: body,
+      RawBody: rawBody,
+      CommandBody: rawBody,
+      From: `email:${senderAddress}`,
+      To: `email:${account.address}`,
+      SessionKey: route.sessionKey,
+      AccountId: route.accountId,
+      ChatType: "direct",
+      ConversationLabel: subject,
+      SenderName: senderAddress,
+      SenderId: senderAddress,
+      Provider: "email",
+      Surface: "email",
+      MessageSid: messageId,
+      OriginatingChannel: "email",
+      OriginatingTo: senderAddress,
+      // Carry email metadata for outbound threading
+      UntrustedContext: [
+        `[email_message_id: ${messageId ?? "unknown"}]`,
+        `[email_subject: ${subject}]`,
+        `[email_from: ${senderAddress}]`,
+      ],
+    });
+
+    // Record the inbound session
+    const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+      agentId: route.agentId,
+    });
+    await core.channel.session.recordInboundSession({
+      storePath,
+      sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+      ctx: ctxPayload,
+      onRecordError: (err) => {
+        context.logGateway.error(`[email] Failed to record session: ${String(err)}`);
+      },
+    });
+
+    // Dispatch to agent and deliver reply via outbound
+    const tableMode = core.channel.text.resolveMarkdownTableMode({
+      cfg,
+      channel: "email",
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+    const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+      cfg,
+      agentId: route.agentId,
+      channel: "email",
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+
+    // Fire-and-forget: dispatch to agent; reply will be sent via outbound adapter
+    void core.channel.reply
+      .dispatchReplyWithBufferedBlockDispatcher({
+        ctx: ctxPayload,
+        cfg,
+        dispatcherOptions: {
+          ...prefixOptions,
+          deliver: async (replyPayload) => {
+            // Send reply email via American Claw outbound API
+            await deliverEmailReply({
+              account,
+              to: senderAddress,
+              subject: subject.startsWith("Re: ") ? subject : `Re: ${subject}`,
+              text: replyPayload.text ?? "",
+              inReplyTo: messageId,
+            });
+          },
+        },
+        replyOptions: {
+          onModelSelected,
+        },
+      })
+      .catch((err) => {
+        context.logGateway.error(`[email] Dispatch failed: ${String(err)}`);
+      });
+
+    // Respond immediately to the gateway caller (American Claw webhook)
+    respond(true, { received: true });
+  };
+}
+
+/**
+ * Send an email reply via American Claw's /api/email/outbound endpoint.
+ */
+async function deliverEmailReply(params: {
+  account: { outboundUrl: string; outboundToken: string };
+  to: string;
+  subject: string;
+  text: string;
+  inReplyTo?: string;
+}): Promise<void> {
+  const { account, to, subject, text, inReplyTo } = params;
+
+  if (!account.outboundUrl || !account.outboundToken) {
+    throw new Error("Email outbound not configured: missing outboundUrl or outboundToken");
+  }
+
+  const body: Record<string, string> = {
+    to,
+    subject,
+    text,
+  };
+  if (inReplyTo) {
+    body.inReplyTo = inReplyTo;
+  }
+
+  const response = await fetch(account.outboundUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${account.outboundToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "unknown");
+    throw new Error(
+      `Email outbound failed (${response.status}): ${errorText}`,
+    );
+  }
+}

--- a/extensions/email/src/runtime.ts
+++ b/extensions/email/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setEmailRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getEmailRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Email runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/email/src/types.ts
+++ b/extensions/email/src/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Resolved email account configuration from openclaw.json.
+ *
+ * Config path: channels.email.accounts.<accountId>
+ *
+ * Example:
+ * ```json
+ * {
+ *   "channels": {
+ *     "email": {
+ *       "accounts": {
+ *         "default": {
+ *           "enabled": true,
+ *           "address": "brian@agent.americanclaw.ai",
+ *           "outboundUrl": "https://americanclaw.ai/api/email/outbound",
+ *           "outboundToken": "<gateway-token>"
+ *         }
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export type EmailAccountConfig = {
+  enabled?: boolean;
+  name?: string;
+  address?: string;
+  outboundUrl?: string;
+  outboundToken?: string;
+  dmPolicy?: "open" | "pairing" | "closed";
+  allowFrom?: Array<string | number>;
+};
+
+export type ResolvedEmailAccount = {
+  accountId: string;
+  name: string;
+  enabled: boolean;
+  address: string;
+  outboundUrl: string;
+  outboundToken: string;
+  dmPolicy: "open" | "pairing" | "closed";
+  allowFrom: Array<string | number>;
+};
+
+/**
+ * Payload sent by American Claw's /api/email/inbound webhook
+ * to the gateway RPC method "email.inbound".
+ */
+export type EmailInboundPayload = {
+  from: string;
+  to: string;
+  subject?: string;
+  text?: string;
+  html?: string;
+  headers?: {
+    messageId?: string;
+    [key: string]: unknown;
+  };
+};
+
+/**
+ * Payload sent to American Claw's /api/email/outbound endpoint.
+ */
+export type EmailOutboundPayload = {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+  inReplyTo?: string;
+  references?: string;
+};


### PR DESCRIPTION
## Summary

Adds an email channel extension (`extensions/email/`) that enables OpenClaw agents to receive and send emails when hosted on American Claw.

**Architecture:**
- **Inbound:** American Claw webhook → gateway RPC `email.inbound` → agent processes message → reply delivered
- **Outbound:** Agent reply → HTTP POST to American Claw `/api/email/outbound` → Resend API → recipient inbox

**Key design decisions:**
- No IMAP/SMTP needed — all email I/O goes through American Claw's APIs
- Gateway RPC handler (`email.inbound`) builds MsgContext with email envelope (subject, sender) and dispatches to agent
- Session key uses `email:{sender-address}` for per-sender conversations
- `dmPolicy` defaults to `"open"` — email addresses are inherently self-authenticating
- Email threading via `In-Reply-To`/`References` headers carried through the reply chain

**Files:**
| File | Purpose |
|------|---------|
| `extensions/email/package.json` | Plugin package manifest |
| `extensions/email/index.ts` | Plugin entry: registers channel + `email.inbound` gateway method |
| `extensions/email/src/runtime.ts` | PluginRuntime holder singleton |
| `extensions/email/src/types.ts` | TypeScript types for config, inbound/outbound payloads |
| `extensions/email/src/accounts.ts` | Config resolution: list/resolve email accounts from openclaw.json |
| `extensions/email/src/channel.ts` | ChannelPlugin definition with config, security, outbound, gateway adapters |
| `extensions/email/src/inbound.ts` | Gateway RPC handler: parses email, builds MsgContext, dispatches to agent, sends reply |

**Config schema** (written by American Claw provisioning):
```json
{
  "channels": {
    "email": {
      "accounts": {
        "default": {
          "enabled": true,
          "address": "agent@agent.americanclaw.ai",
          "outboundUrl": "https://americanclaw.ai/api/email/outbound",
          "outboundToken": "<gateway-token>"
        }
      }
    }
  }
}
```

## Test plan

- [ ] Install plugin in local OpenClaw dev environment
- [ ] Verify `email.inbound` gateway method is registered on startup
- [ ] Send test email → verify agent receives message with subject/body context
- [ ] Verify agent reply triggers POST to `/api/email/outbound` with correct payload
- [ ] Verify email threading: reply has `In-Reply-To` header matching original `Message-ID`
- [ ] Verify session continuity: second email from same sender continues conversation
- [ ] Test with empty body / HTML-only emails (fallback strip-HTML path)
- [ ] Verify disabled account returns 503 error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)